### PR TITLE
Adding templates for change management

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,17 @@
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+
+  1.
+  1.
+  1.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Subsystem:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+
+## Related Links
+
+
+## Testing
+
+
+## Docs
+[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)


### PR DESCRIPTION
## Description
Adding templates for SOC2 purposes to show change management considerations.

## Testing
- read the templates, verify they are present for issues & PRs

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
