### PR TITLE
Fixed vulnerabilities by changing base image to alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
         uses: docker://docker.io/aquasec/trivy:0.2.1
         timeout-minutes: 5
         with:
-          args: --cache-dir /var/lib/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          args: --cache-dir /var/lib/trivy --severity "CRITICAL,HIGH" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
     env:
       IMAGE_NAME: ${{ github.repository }}:latest
     steps:
-      - name: Debug action
-        uses: hmarr/debug-action@v2.0.0
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - name: Get Image Name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          args: --cache-dir /var/lib/trivy --severity "UNKNOWN,HIGH,CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          args: --cache-dir /var/lib/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          args: --cache-dir /var/lib/trivy --severity "UNKNOWN,HIGH,CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}
+          args: --cache-dir /var/lib/trivy --severity "UNKNOWN,HIGH,CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
           build_extra_args: "--build-arg BUILDKIT_INLINE_CACHE=1"
       - name: Scan Image for Vulnerabilities
         uses: docker://docker.io/aquasec/trivy:0.2.1
-        continue-on-error: true
         timeout-minutes: 5
         with:
           args: --cache-dir /var/lib/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - name: Get Image Name
-        run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/rails" >> $GITHUB_ENV
+        run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/default" >> $GITHUB_ENV
       - name: Build & Test
         id: build-docker-image-using-cache
         uses: whoan/docker-build-with-cache-action@v5.11.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.6.6-alpine
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -7,7 +7,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION v12.8.1
 RUN mkdir $NVM_DIR \
-  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | sh \
   && source $NVM_DIR/nvm.sh \
   && nvm install $NODE_VERSION \
   && nvm alias default $NODE_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,21 @@ RUN apk add --update --no-cache \
   imagemagick6-dev \
   imagemagick6-libs
 
+# Need git for some gems
+RUN apk add --update --no-cache git
+
 # Upgrade to security issues
-RUN apk add python3=3.8.8-r0
+# https://stackoverflow.com/questions/61875869/ubuntu-20-04-upgrade-python-missing-libffi-so-6#61876234
+RUN \
+  apk add python3=3.8.8-r0 \
+  && ln -s /usr/lib/libffi.so.7 /usr/lib/libffi.so.6
+
+# https://github.com/locomotivecms/wagon/issues/340
+WORKDIR /
+COPY ./entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 3000
+CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV GEM_HOME "/usr/local/bundle"
 ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
 RUN mkdir -p ${GEM_HOME} \
-  && gem install bundler -v 1.3.0
+  && gem install bundler -v 2.1.4
 # https://jer-k.github.io/update-gem-dockerfile-alpine-linux
 RUN apk --update add --virtual \
   run-dependencies \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,7 @@
-FROM ubuntu:20.04
+FROM ruby:2.6.5
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
-
-# Install RVM & Ruby
-# https://github.com/rvm/ubuntu_rvm
-RUN \
-  apt-get update \
-  && apt-get install -y software-properties-common \
-  && apt-add-repository -y ppa:rael-gc/rvm \
-  && apt-get update \
-  && apt-get install -y rvm \
-  && apt-get autoremove && apt-get autoclean && apt-get clean \
-  # && usermod -a -G rvm $(whoami) \
-  && source ~/.bashrc
-RUN /usr/share/rvm/bin/rvm user gemsets && /usr/share/rvm/bin/rvm install 2.6.5
-
-RUN ln -s /usr/share/rvm/rubies/ruby-2.6.5/bin/ruby /usr/bin/ruby
-RUN ruby -v
-RUN ln -s /usr/share/rvm/rubies/ruby-2.6.5/bin/gem /usr/bin/gem
-RUN gem install executable-hooks -v ">=1.3.2" && gem regenerate_binstubs
-RUN gem -v
 
 # https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
 ENV NVM_DIR /usr/local/nvm
@@ -30,14 +11,13 @@ RUN mkdir $NVM_DIR \
   && source $NVM_DIR/nvm.sh \
   && nvm install $NODE_VERSION \
   && nvm alias default $NODE_VERSION \
-  && nvm use default \
-  && source ~/.bashrc
+  && nvm use default
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+RUN source ~/.bashrc && node -v
 
 RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/node /usr/bin/node
 RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/npm /usr/bin/npm
-RUN node -v
 
 # https://classic.yarnpkg.com/en/docs/install#debian-stable
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
@@ -53,9 +33,7 @@ ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
 RUN gem install bundler -v 1.3.0
 # https://stackoverflow.com/questions/3116015/how-to-install-postgresqls-pg-gem-on-ubuntu#3116128
-RUN \
-  apt-get install -y libpq-dev \
-  && gem install pg -- --with-pg-lib=/usr/lib
+RUN gem install pg -- --with-pg-lib=/usr/lib
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /
@@ -63,6 +41,15 @@ COPY ./entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+# Update for security issues
+RUN \
+  apt-get update \
+  && apt-get install -y debsecan \
+  && apt-get install $(debsecan --suite buster --format packages --only-fixed)
+
+# Cleanup apt
+RUN apt-get -y autoremove && apt-get autoclean && apt-get clean
 
 EXPOSE 3000
 CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:experimental
-
 FROM ruby:2.6.6-alpine3.13
 
 ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
@@ -14,19 +12,21 @@ RUN unset BUNDLE_BIN
 ENV GEM_HOME "/usr/local/bundle"
 ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
-RUN gem install bundler -v 1.3.0
+RUN mkdir -p ${GEM_HOME} \
+  && gem install bundler -v 1.3.0
 # https://jer-k.github.io/update-gem-dockerfile-alpine-linux
 RUN \
   apk --update add --virtual run-dependencies \
     build-base \
     postgresql-client \
     postgresql-dev
-RUN \
-  mkdir -p ${GEM_HOME} \
-  && gem install pg -- --with-pg-lib=/usr/lib
+RUN gem install pg -- --with-pg-lib=/usr/lib
 
 # Upgrade to security issues
-RUN apk add python3=3.8.8-r0
+RUN \
+  ls -lah /usr/local/bundle \
+  && ${GEM_HOME} \
+  && apk add python3=3.8.8-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,11 @@
-FROM ruby:2.6.5
+# syntax=docker/dockerfile:experimental
 
-# Replace shell with bash so we can source files
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+FROM ruby:2.6.6-alpine3.13 AS rails
 
-# https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v12.8.1
-RUN mkdir $NVM_DIR \
-  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
-  && source $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && nvm alias default $NODE_VERSION \
-  && nvm use default
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-RUN source ~/.bashrc && node -v
-
-RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/node /usr/bin/node
-RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/npm /usr/bin/npm
-
-# https://classic.yarnpkg.com/en/docs/install#debian-stable
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update && apt-get install -yqq --no-install-recommends yarn
+ENV NODE_VERSION 14.16.0-r0
+RUN \
+  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} \
+  && npm install --global yarn
 
 # Don't inherit local env settings when setting up bundler
 RUN unset BUNDLE_PATH
@@ -31,25 +14,15 @@ RUN unset BUNDLE_BIN
 ENV GEM_HOME "/usr/local/bundle"
 ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
-RUN gem install bundler -v 1.3.0
-# https://stackoverflow.com/questions/3116015/how-to-install-postgresqls-pg-gem-on-ubuntu#3116128
+RUN mkdir -p ${GEM_HOME} \
+  && gem install bundler -v 1.3.0
+# https://jer-k.github.io/update-gem-dockerfile-alpine-linux
+RUN \
+  apk --update add --virtual run-dependencies \
+    build-base \
+    postgresql-client \
+    postgresql-dev
 RUN gem install pg -- --with-pg-lib=/usr/lib
 
-# https://github.com/locomotivecms/wagon/issues/340
-WORKDIR /
-COPY ./entrypoint.sh entrypoint.sh
-RUN chmod +x entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
-
-# Update for security issues
-RUN \
-  apt-get update \
-  && apt-get install -y debsecan \
-  && apt-get install $(debsecan --suite buster --format packages --only-fixed)
-
-# Cleanup apt
-RUN apt-get -y autoremove && apt-get autoclean && apt-get clean
-
-EXPOSE 3000
-CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]
+# Upgrade to security issues
+RUN apk add python3=3.8.8-r0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
+# syntax=docker/dockerfile:experimental
+
 FROM ruby:2.6.6-alpine3.13
+
+# Prefer buikdkit cache for apk, don't include this in final image
+RUN rm -rf /var/lib/apk/
 
 ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
 RUN \
+  --mount=type=cache,id=apk,target=/var/lib/apk/ \
   echo "${ALPINE_MIRROR}/edge/main" >> /etc/apk/repositories \
   && apk add --no-cache nodejs-current --repository="http://dl-cdn.alpinelinux.org/alpine/edge/community"
 
@@ -16,6 +22,7 @@ RUN mkdir -p ${GEM_HOME} \
   && gem install bundler -v 1.3.0
 # https://jer-k.github.io/update-gem-dockerfile-alpine-linux
 RUN \
+  --mount=type=cache,id=apk,target=/var/lib/apk/ \
   apk --update add --virtual run-dependencies \
     build-base \
     postgresql-client \
@@ -23,7 +30,7 @@ RUN \
 RUN gem install pg -- --with-pg-lib=/usr/lib
 
 # Upgrade to security issues
-RUN apk add python3=3.8.8-r0
+RUN --mount=type=cache,id=apk,target=/var/lib/apk/ apk add python3=3.8.8-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-slim-buster
+FROM ruby:2.6.6
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ruby:2.6.6-alpine3.13
 
-ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
+ENV NODE_VERSION 14.16.0-r0
 RUN \
-  echo "${ALPINE_MIRROR}/edge/main" >> /etc/apk/repositories \
-  && apk add --no-cache nodejs-current --repository="http://dl-cdn.alpinelinux.org/alpine/edge/community"
+  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} \
+  && npm install --global yarn
 
 # Don't inherit local env settings when setting up bundler
 RUN unset BUNDLE_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-alpine
+FROM ruby:2.6.6
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -7,7 +7,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION v12.8.1
 RUN mkdir $NVM_DIR \
-  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | sh \
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
   && source $NVM_DIR/nvm.sh \
   && nvm install $NODE_VERSION \
   && nvm alias default $NODE_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,7 @@ RUN \
 RUN gem install pg -- --with-pg-lib=/usr/lib
 
 # Upgrade to security issues
-RUN \
-  ls -lah /usr/local/bundle \
-  && ${GEM_HOME} \
-  && apk add python3=3.8.8-r0
+RUN apk add python3=3.8.8-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-buster
+FROM ruby:2.6.6-alpine3.13
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,10 @@
 
 FROM ruby:2.6.6-alpine3.13
 
-# Prefer buikdkit cache for apk, don't include this in final image
-RUN rm -rf /var/lib/apk/
-
-RUN --mount=type=cache,id=apk,target=/var/lib/apk/ apk update
+RUN apk update
 
 ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
 RUN \
-  --mount=type=cache,id=apk,target=/var/lib/apk/ \
   echo "${ALPINE_MIRROR}/edge/main" >> /etc/apk/repositories \
   && apk add --no-cache nodejs-current --repository="http://dl-cdn.alpinelinux.org/alpine/edge/community"
 
@@ -23,7 +19,6 @@ ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 RUN gem install bundler -v 1.3.0
 # https://jer-k.github.io/update-gem-dockerfile-alpine-linux
 RUN \
-  --mount=type=cache,id=apk,target=/var/lib/apk/ \
   apk --update add --virtual run-dependencies \
     build-base \
     postgresql-client \
@@ -34,7 +29,6 @@ RUN \
 
 # Upgrade to security issues
 RUN \
-  --mount=type=cache,id=apk,target=/var/lib/apk/ \
   apk add python3=3.8.8-r0
 
 # https://github.com/locomotivecms/wagon/issues/340

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.6.6-stretch
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,9 @@ RUN \
     build-base \
     postgresql-client \
     postgresql-dev
-RUN gem install pg -- --with-pg-lib=/usr/lib
+RUN \
+  mkdir -p ${GEM_HOME} \
+  && gem install pg -- --with-pg-lib=/usr/lib
 
 # Upgrade to security issues
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 RUN \
   apt-get update \
   && apt-get install -y debsecan \
+  && apt-get upgrade -y \
   && apt-get install $(debsecan --suite buster --format packages --only-fixed)
 
 # Cleanup apt

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 RUN \
   apt-get update \
   && apt-get install -y debsecan \
-  && apt-get upgrade -y \
   && apt-get install $(debsecan --suite buster --format packages --only-fixed)
 
 # Cleanup apt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 
 FROM ruby:2.6.6-alpine3.13
 
+# Prefer buikdkit cache for apk, don't include this in final image
+RUN rm -rf /var/lib/apk/
+
 RUN --mount=type=cache,id=apk,target=/var/lib/apk/ apk update
 
 ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
@@ -26,6 +29,9 @@ RUN \
     postgresql-client \
     postgresql-dev
 RUN gem install pg -- --with-pg-lib=/usr/lib
+
+# Upgrade to fix security issues
+RUN --mount=type=cache,id=apk,target=/var/lib/apk/ apk upgrade
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,14 @@
+# syntax=docker/dockerfile:experimental
+
 FROM ruby:2.6.6-alpine3.13
 
-# Replace shell with bash so we can source files
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN --mount=type=cache,id=apk,target=/var/lib/apk/ apk update
 
-# https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION v12.8.1
-RUN mkdir $NVM_DIR \
-  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
-  && source $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && nvm alias default $NODE_VERSION \
-  && nvm use default
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-RUN source ~/.bashrc && node -v
-
-RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/node /usr/bin/node
-RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/npm /usr/bin/npm
-
-# https://classic.yarnpkg.com/en/docs/install#debian-stable
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update && apt-get install -yqq --no-install-recommends yarn
+ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
+RUN \
+  --mount=type=cache,id=apk,target=/var/lib/apk/ \
+  echo "${ALPINE_MIRROR}/edge/main" >> /etc/apk/repositories \
+  && apk add --no-cache nodejs-current --repository="http://dl-cdn.alpinelinux.org/alpine/edge/community"
 
 # Don't inherit local env settings when setting up bundler
 RUN unset BUNDLE_PATH
@@ -32,7 +18,13 @@ ENV GEM_HOME "/usr/local/bundle"
 ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
 RUN gem install bundler -v 1.3.0
-# https://stackoverflow.com/questions/3116015/how-to-install-postgresqls-pg-gem-on-ubuntu#3116128
+# https://jer-k.github.io/update-gem-dockerfile-alpine-linux
+RUN \
+  --mount=type=cache,id=apk,target=/var/lib/apk/ \
+  apk --update add --virtual run-dependencies \
+    build-base \
+    postgresql-client \
+    postgresql-dev
 RUN gem install pg -- --with-pg-lib=/usr/lib
 
 # https://github.com/locomotivecms/wagon/issues/340

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,20 @@ ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 RUN mkdir -p ${GEM_HOME} \
   && gem install bundler -v 1.3.0
 # https://jer-k.github.io/update-gem-dockerfile-alpine-linux
-RUN \
-  apk --update add --virtual run-dependencies \
-    build-base \
-    postgresql-client \
-    postgresql-dev
+RUN apk --update add --virtual \
+  run-dependencies \
+  build-base \
+  postgresql-client \
+  postgresql-dev
 RUN gem install pg -- --with-pg-lib=/usr/lib
+
+# https://github.com/rmagick/rmagick/issues/834
+RUN apk add --update --no-cache \
+  build-base \
+  imagemagick6 \
+  imagemagick6-c++ \
+  imagemagick6-dev \
+  imagemagick6-libs
 
 # Upgrade to security issues
 RUN apk add python3=3.8.8-r0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:2.6.6-slim-buster
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-stretch
+FROM ruby:2.7.2-buster
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 
 FROM ruby:2.6.6-alpine3.13
 
-RUN apk update
-
 ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
 RUN \
   echo "${ALPINE_MIRROR}/edge/main" >> /etc/apk/repositories \
@@ -28,8 +26,7 @@ RUN \
   && gem install pg -- --with-pg-lib=/usr/lib
 
 # Upgrade to security issues
-RUN \
-  apk add python3=3.8.8-r0
+RUN apk add python3=3.8.8-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,48 @@
-FROM ruby:2.6.6-alpine3.13
+FROM ubuntu:20.04
 
-ENV NODE_VERSION 14.16.0-r0
+# Replace shell with bash so we can source files
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Install RVM & Ruby
+# https://github.com/rvm/ubuntu_rvm
 RUN \
-  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} \
-  && npm install --global yarn
+  apt-get update \
+  && apt-get install -y software-properties-common \
+  && apt-add-repository -y ppa:rael-gc/rvm \
+  && apt-get update \
+  && apt-get install -y rvm \
+  && apt-get autoremove && apt-get autoclean && apt-get clean \
+  # && usermod -a -G rvm $(whoami) \
+  && source ~/.bashrc
+RUN /usr/share/rvm/bin/rvm user gemsets && /usr/share/rvm/bin/rvm install 2.6.5
+
+RUN ln -s /usr/share/rvm/rubies/ruby-2.6.5/bin/ruby /usr/bin/ruby
+RUN ruby -v
+RUN ln -s /usr/share/rvm/rubies/ruby-2.6.5/bin/gem /usr/bin/gem
+RUN gem install executable-hooks -v ">=1.3.2" && gem regenerate_binstubs
+RUN gem -v
+
+# https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION v12.8.1
+RUN mkdir $NVM_DIR \
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
+  && source $NVM_DIR/nvm.sh \
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default \
+  && source ~/.bashrc
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/node /usr/bin/node
+RUN ln -s /usr/local/nvm/versions/node/$NODE_VERSION/bin/npm /usr/bin/npm
+RUN node -v
+
+# https://classic.yarnpkg.com/en/docs/install#debian-stable
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt-get update && apt-get install -yqq --no-install-recommends yarn
 
 # Don't inherit local env settings when setting up bundler
 RUN unset BUNDLE_PATH
@@ -12,18 +51,18 @@ RUN unset BUNDLE_BIN
 ENV GEM_HOME "/usr/local/bundle"
 ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
-RUN mkdir -p ${GEM_HOME} \
-  && gem install bundler -v 1.3.0
-# https://jer-k.github.io/update-gem-dockerfile-alpine-linux
+RUN gem install bundler -v 1.3.0
+# https://stackoverflow.com/questions/3116015/how-to-install-postgresqls-pg-gem-on-ubuntu#3116128
 RUN \
-  apk --update add --virtual run-dependencies \
-    build-base \
-    postgresql-client \
-    postgresql-dev
-RUN gem install pg -- --with-pg-lib=/usr/lib
+  apt-get install -y libpq-dev \
+  && gem install pg -- --with-pg-lib=/usr/lib
 
-# Upgrade to security issues
-RUN apk add python3=3.8.8-r0
+# https://github.com/locomotivecms/wagon/issues/340
+WORKDIR /
+COPY ./entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3000
 CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-# syntax=docker/dockerfile:experimental
-
 FROM ruby:2.6.6-alpine3.13
-
-# Prefer buikdkit cache for apk, don't include this in final image
-RUN rm -rf /var/lib/apk/
 
 ENV ALPINE_MIRROR "http://dl-cdn.alpinelinux.org/alpine"
 RUN \
-  --mount=type=cache,id=apk,target=/var/lib/apk/ \
   echo "${ALPINE_MIRROR}/edge/main" >> /etc/apk/repositories \
   && apk add --no-cache nodejs-current --repository="http://dl-cdn.alpinelinux.org/alpine/edge/community"
 
@@ -22,7 +16,6 @@ RUN mkdir -p ${GEM_HOME} \
   && gem install bundler -v 1.3.0
 # https://jer-k.github.io/update-gem-dockerfile-alpine-linux
 RUN \
-  --mount=type=cache,id=apk,target=/var/lib/apk/ \
   apk --update add --virtual run-dependencies \
     build-base \
     postgresql-client \
@@ -30,7 +23,7 @@ RUN \
 RUN gem install pg -- --with-pg-lib=/usr/lib
 
 # Upgrade to security issues
-RUN --mount=type=cache,id=apk,target=/var/lib/apk/ apk add python3=3.8.8-r0
+RUN apk add python3=3.8.8-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,5 @@ RUN gem install pg -- --with-pg-lib=/usr/lib
 # Upgrade to security issues
 RUN apk add python3=3.8.8-r0
 
-# https://github.com/locomotivecms/wagon/issues/340
-WORKDIR /
-COPY ./entrypoint.sh entrypoint.sh
-RUN chmod +x entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
-
 EXPOSE 3000
 CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5
+FROM ruby:2.6.6
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:2.6.6-alpine3.13 AS rails
+FROM ruby:2.6.6-alpine3.13
 
 ENV NODE_VERSION 14.16.0-r0
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ RUN \
     postgresql-dev
 RUN gem install pg -- --with-pg-lib=/usr/lib
 
-# Upgrade to fix security issues
-RUN --mount=type=cache,id=apk,target=/var/lib/apk/ apk upgrade
+# Upgrade to security issues
+RUN \
+  --mount=type=cache,id=apk,target=/var/lib/apk/ \
+  apk add python3=3.8.8-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 cp /etc/hosts /etc/hosts.new
 sed -i 's/::1\tlocalhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/' /etc/hosts.new
-cp -f /etc/hosts.new /etc/hosts
+cat /etc/hosts.new > /etc/hosts
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-cp /etc/hosts /etc/hosts.new
-sed -i 's/::1\tlocalhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/' /etc/hosts.new
-cp -f /etc/hosts.new /etc/hosts
-
-exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cp /etc/hosts /etc/hosts.new
+sed -i 's/::1\tlocalhost ip6-localhost ip6-loopback/::1 ip6-localhost ip6-loopback/' /etc/hosts.new
+cp -f /etc/hosts.new /etc/hosts
+
+exec "$@"


### PR DESCRIPTION
## Description

Added vulnerability scanning on pull-requests and merge to `master`.

Potential concerns around Ruby 2.6.6 and Node 15.12.0 down the chain, can do further testing with our sub-image after.

We will need to tag this `2.6.6-alpine3.13-node15.12.0` after merging to `master`.

## Related Links

* https://app.asana.com/0/1199567256179283/1200044890720123/f
* https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
* https://stackoverflow.com/questions/58725215/how-to-install-nodejs-v13-0-1-in-alpine3-8
* https://jer-k.github.io/update-gem-dockerfile-alpine-linux
* https://github.com/rmagick/rmagick/issues/834

## Testing

* Confirm no vulnerabilities above MEDIUM exist
* Confirm new CI is passing

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
