### PR TITLE
Upgraded Ruby to 3.0.1

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:3.0.1-alpine3.13 AS ruby-base
+FROM ruby:3.0.1-alpine3.13
 
 ENV NODE_VERSION 14.16.1-r1
 ENV APK_TOOLS_VERSION 2.12.5-r0

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -38,7 +38,6 @@ RUN apk add --update --no-cache git
 
 # Upgrade to fix known security issues
 RUN apk add \
-  musl=1.2.2_pre2-r0 \
   ruby=2.7.3-r0
 
 # https://github.com/locomotivecms/wagon/issues/340

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:2.6.5-alpine3.11
+FROM ruby:3.0.1-alpine3.13 AS ruby-base
 
-ENV NODE_VERSION 12.22.1-r0
+ENV NODE_VERSION 14.16.1-r1
+ENV APK_TOOLS_VERSION 2.12.5-r0
 RUN \
-  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} apk-tools=2.10.6-r0\
+  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} apk-tools=${APK_TOOLS_VERSION} \
   && npm install --global yarn
 
 # Don't inherit local env settings when setting up bundler
@@ -34,16 +35,6 @@ RUN apk add --update --no-cache \
 
 # Need git for some gems
 RUN apk add --update --no-cache git
-
-# Upgrade to fix known security issues
-RUN apk add \
-  python3=3.8.2-r2 \
-  busybox=1.31.1-r10 \
-  gcc=9.3.0-r0 \
-  perl=5.30.3-r0 \
-  sqlite=3.30.1-r2 \
-  musl-utils=1.1.24-r3 \
-  libgcc=9.3.0-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -36,6 +36,11 @@ RUN apk add --update --no-cache \
 # Need git for some gems
 RUN apk add --update --no-cache git
 
+# Upgrade to fix known security issues
+RUN apk add \
+  musl=1.2.2_pre2-r0 \
+  ruby=2.7.3-r0
+
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /
 COPY ./entrypoint.sh entrypoint.sh

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:3.0.1-buster AS ruby-base
+FROM ruby:3.0.1-buster
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:2.6.5-buster
+FROM ruby:3.0.1-buster AS ruby-base
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -52,6 +52,3 @@ COPY ./entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-
-EXPOSE 3000
-CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]


### PR DESCRIPTION
## Description

* Upgraded base images to `ruby:3.0.1`
* Changed package versions for `alpine3.13` that are available
* Removed package upgrades for `alpine3.13` that are not available

Need to tag images after merging to `master`.

* `3.0.1-alpine3.13-node14.16.1`
* `3.0.1-bullseye-node12.8.1`

## Related Links

* https://app.asana.com/0/1164982780054583/1200296879840034/f

## Testing

* Check there are no security vulnerabilities for the `alpine` image, except for `musl`
* Check CI passes

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
