### PR TITLE
Changed CI to push image caches to different names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,11 @@ jobs:
     strategy:
       matrix:
         architecture: [alpine, debian]
-    env:
-      IMAGE_NAME: ${{ github.repository }}:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - name: Get Image Name
-        run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/default" >> $GITHUB_ENV
+        run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/${{ matrix.architecture }}" >> $GITHUB_ENV
       - name: Build & Test
         id: build-docker-image-using-cache
         uses: whoan/docker-build-with-cache-action@v5.11.0


### PR DESCRIPTION
## Description

Changed the cache for each architecture to use a different cache name, i.e. `image_name`.

## Related Links

* https://app.asana.com/0/1200379515898093/1200385916593831/f
* https://github.com/marketplace/actions/build-docker-images-using-cache

## Testing

1. Check there's a package for `debian`, `alpine`, and `*-stages`
2. Confirm there are no other packages created

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
