### PR TITLE
Added workflow step to publish images to latest-* to Github packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ true || github.ref == 'refs/heads/master' }}
     needs:
       - vulnerability-scanning
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     name: Vulnerability Scanning
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      full_image_name_alpine: ${{ steps.output-full-image-name.outputs.FULL_IMAGE_NAME_alpine }}
+      full_image_name_debian: ${{ steps.output-full-image-name.outputs.FULL_IMAGE_NAME_debian }}
     strategy:
       matrix:
         architecture: [alpine, debian]
@@ -35,6 +38,9 @@ jobs:
           push_git_tag: true
           dockerfile: Dockerfile.${{ matrix.architecture }}
           build_extra_args: --build-arg BUILDKIT_INLINE_CACHE=1
+      - name: Output the Full Image Name
+        id: output-full-image-name
+        run: echo '::set-output name=FULL_IMAGE_NAME_${{ matrix.architecture }}::${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}'
       - name: Scan Image for Vulnerabilities
         uses: docker://docker.io/aquasec/trivy:0.2.1
         timeout-minutes: 5
@@ -56,7 +62,12 @@ jobs:
     strategy:
       matrix:
         architecture: [alpine, debian]
+    env:
+      CACHE_IMAGE_NAME_alpine: ${{ needs.build-test-packages.outputs.full_image_name_alpine }}
+      CACHE_IMAGE_NAME_debian: ${{ needs.build-test-packages.outputs.full_image_name_debian }}
     steps:
+      - name: Get Image Name
+        run: echo "CACHE_IMAGE_NAME=${CACHE_IMAGE_NAME_${{ matrix.architecture }}}" >> $GITHUB_ENV
       - name: Build and publish Docker Image to GitHub Packages Registry
         uses: VaultVulp/gp-docker-action@1.1.8
         with:
@@ -64,4 +75,4 @@ jobs:
           image-name: rails
           image-tag: latest-${{ matrix.architecture }}
           dockerfile: Dockerfile.${{ matrix.architecture }}
-          custom-args: --build-arg BUILDKIT_INLINE_CACHE=1
+          custom-args: --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from=${{ env.CACHE_IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       CACHE_IMAGE_NAME_alpine: ${{ needs.build-test-packages.outputs.full_image_name_alpine }}
       CACHE_IMAGE_NAME_debian: ${{ needs.build-test-packages.outputs.full_image_name_debian }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
       - name: Get Image Name
         run: echo "CACHE_IMAGE_NAME=${CACHE_IMAGE_NAME_${{ matrix.architecture }}}" >> $GITHUB_ENV
       - name: Build and publish Docker Image to GitHub Packages Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+      - name: Cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: /var/lib/trivy
+          key: trivy-${{ github.sha }}
       - name: Get Image Name
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/${{ matrix.architecture }}" >> $GITHUB_ENV
       - name: Build & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v2.1.5
         with:
           path: /var/lib/trivy
-          key: trivy-${{ github.sha }}
+          key: trivy-${{ matrix.architecture }}-${{ github.sha }}
       - name: Get Image Name
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/${{ matrix.architecture }}" >> $GITHUB_ENV
       - name: Build & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
+    needs:
+      - vulnerability-scanning
     timeout-minutes: 10
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    if: ${{ true || github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs:
       - vulnerability-scanning
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI & CD
 
 on:
   pull_request:
@@ -28,13 +28,13 @@ jobs:
         timeout-minutes: 5
         with:
           username: ${{ github.actor }}
-          password: "${{ secrets.GITHUB_TOKEN }}"
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: docker.pkg.github.com
           image_name: ${{ env.IMAGE_NAME }}
           image_tag: ${{ github.sha }}
           push_git_tag: true
           dockerfile: Dockerfile.${{ matrix.architecture }}
-          build_extra_args: "--build-arg BUILDKIT_INLINE_CACHE=1"
+          build_extra_args: --build-arg BUILDKIT_INLINE_CACHE=1
       - name: Scan Image for Vulnerabilities
         uses: docker://docker.io/aquasec/trivy:0.2.1
         timeout-minutes: 5
@@ -45,3 +45,21 @@ jobs:
         timeout-minutes: 5
         with:
           args: --cache-dir /var/lib/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/master' }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        architecture: [alpine, debian]
+    steps:
+      - name: Build and publish Docker Image to GitHub Packages Registry
+        uses: VaultVulp/gp-docker-action@1.1.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          image-name: rails
+          image-tag: latest-${{ matrix.architecture }}
+          dockerfile: Dockerfile.${{ matrix.architecture }}
+          custom-args: --build-arg BUILDKIT_INLINE_CACHE=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+./git
+./github
+Dockerfile*
+LICENSE


### PR DESCRIPTION
## Description

Changed previous _CI_ workflow to include _CD_ as well, where only on `master` does it then publish the images to `latest-alpine` and `latest-debian`.

## Related Links

* https://app.asana.com/0/0/1200385916593837/f
* https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry
* https://github.com/marketplace/actions/build-and-publish-docker-image-to-github-packages-registry
* https://github.com/CareerJSM/docker-rails/actions/runs/879144355

## Testing

1. Run the workflow with `if: ${{ github.ref == 'refs/heads/master' }}` disabled
2. Check that two images were deployed to the Github packages for this repository
3. Delete the packages and re-enable `if: ${{ github.ref == 'refs/heads/master' }}`

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
