### PR TITLE
Changed trivy to use Github marketplace item

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Cache
         uses: actions/cache@v2.1.5
         with:
-          path: /var/lib/trivy
+          path: /cache/trivy
           key: trivy-${{ matrix.architecture }}-${{ github.sha }}
+          restore-keys: |
+            trivy-${{ matrix.architecture }}-${{ github.sha }}
+            trivy-${{ matrix.architecture }}-
       - name: Get Image Name
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/${{ matrix.architecture }}" >> $GITHUB_ENV
       - name: Build & Test
@@ -47,15 +50,15 @@ jobs:
         id: output-full-image-name
         run: echo '::set-output name=FULL_IMAGE_NAME_${{ matrix.architecture }}::${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}'
       - name: Scan Image for Vulnerabilities
-        uses: docker://docker.io/aquasec/trivy:0.2.1
+        uses: docker://docker.io/aquasec/trivy:0.18.3
         timeout-minutes: 5
         with:
-          args: --cache-dir /var/lib/trivy --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          args: --cache-dir /cache/trivy --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
       - name: Scan Image for Vulnerabilities
-        uses: docker://docker.io/aquasec/trivy:0.2.1
+        uses: docker://docker.io/aquasec/trivy:0.18.3
         timeout-minutes: 5
         with:
-          args: --cache-dir /var/lib/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          args: --cache-dir /cache/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
 
   publish:
     name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,12 @@ jobs:
         id: output-full-image-name
         run: echo '::set-output name=FULL_IMAGE_NAME_${{ matrix.architecture }}::${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}'
       - name: Scan Image for Vulnerabilities
-        uses: docker://docker.io/aquasec/trivy:0.18.3
+        uses: docker://docker.io/aquasec/trivy:0.2.1
         timeout-minutes: 5
         with:
           args: --cache-dir /cache/trivy --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
       - name: Scan Image for Vulnerabilities
-        uses: docker://docker.io/aquasec/trivy:0.18.3
+        uses: docker://docker.io/aquasec/trivy:0.2.1
         timeout-minutes: 5
         with:
           args: --cache-dir /cache/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
-      - name: Cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: /cache/trivy
-          key: trivy-${{ matrix.architecture }}-${{ github.sha }}
-          restore-keys: |
-            trivy-${{ matrix.architecture }}-${{ github.sha }}
-            trivy-${{ matrix.architecture }}-
       - name: Get Image Name
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/${{ matrix.architecture }}" >> $GITHUB_ENV
       - name: Build & Test
@@ -53,10 +45,14 @@ jobs:
         uses: aquasecurity/trivy-action@0.0.17
         with:
           image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-          cache-dir: /cache/trivy
           format: template
           template: "@/contrib/sarif.tpl"
           output: trivy-results.sarif
+      - name: Aqua Security Trivy
+        uses: aquasecurity/trivy-action@0.0.17
+        with:
+          image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          format: table
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
         with:
@@ -65,7 +61,6 @@ jobs:
         uses: aquasecurity/trivy-action@0.0.17
         with:
           image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-          cache-dir: /cache/trivy
           exit-code: 1
           severity: CRITICAL
           format: table

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,6 @@ jobs:
           format: template
           template: "@/contrib/sarif.tpl"
           output: trivy-results.sarif
-      - name: Aqua Security Trivy
-        uses: aquasecurity/trivy-action@0.0.17
-        with:
-          image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-          cache-dir: /cache/trivy
-          format: table
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,20 +45,25 @@ jobs:
         uses: aquasecurity/trivy-action@0.0.17
         with:
           image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-          format: "template"
+          format: template
           template: "@/contrib/sarif.tpl"
-          output: "trivy-results.sarif"
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: "trivy-results.sarif"
+          output: trivy-results.sarif
       - name: Aqua Security Trivy
         uses: aquasecurity/trivy-action@0.0.17
         with:
           image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-          exit-code: "1"
-          severity: "CRITICAL"
-          format: "table"
+          format: table
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: trivy-results.sarif
+      - name: Aqua Security Trivy
+        uses: aquasecurity/trivy-action@0.0.17
+        with:
+          image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          exit-code: 1
+          severity: CRITICAL
+          format: table
 
   publish:
     name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
-      - name: Cache
-        uses: actions/cache@v2.1.5
-        with:
-          path: /cache/trivy
-          key: trivy-${{ matrix.architecture }}-${{ github.sha }}
-          restore-keys: |
-            trivy-${{ matrix.architecture }}-${{ github.sha }}
-            trivy-${{ matrix.architecture }}-
       - name: Get Image Name
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/${{ matrix.architecture }}" >> $GITHUB_ENV
       - name: Build & Test
@@ -49,16 +41,24 @@ jobs:
       - name: Output the Full Image Name
         id: output-full-image-name
         run: echo '::set-output name=FULL_IMAGE_NAME_${{ matrix.architecture }}::${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}'
-      - name: Scan Image for Vulnerabilities
-        uses: docker://docker.io/aquasec/trivy:0.2.1
-        timeout-minutes: 5
+      - name: Aqua Security Trivy
+        uses: aquasecurity/trivy-action@0.0.17
         with:
-          args: --cache-dir /cache/trivy --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-      - name: Scan Image for Vulnerabilities
-        uses: docker://docker.io/aquasec/trivy:0.2.1
-        timeout-minutes: 5
+          image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          format: "template"
+          template: "@/contrib/sarif.tpl"
+          output: "trivy-results.sarif"
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
         with:
-          args: --cache-dir /cache/trivy --severity "CRITICAL" --exit-code 1 --no-progress ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          sarif_file: "trivy-results.sarif"
+      - name: Aqua Security Trivy
+        uses: aquasecurity/trivy-action@0.0.17
+        with:
+          image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          exit-code: "1"
+          severity: "CRITICAL"
+          format: "table"
 
   publish:
     name: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,6 @@ jobs:
           format: template
           template: "@/contrib/sarif.tpl"
           output: trivy-results.sarif
-      - name: Aqua Security Trivy
-        uses: aquasecurity/trivy-action@0.0.17
-        with:
-          image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-          format: table
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+      - name: Cache
+        uses: actions/cache@v2.1.5
+        with:
+          path: /cache/trivy
+          key: trivy-${{ matrix.architecture }}-${{ github.sha }}
+          restore-keys: |
+            trivy-${{ matrix.architecture }}-${{ github.sha }}
+            trivy-${{ matrix.architecture }}-
       - name: Get Image Name
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | awk '{print tolower($0)}')/${{ matrix.architecture }}" >> $GITHUB_ENV
       - name: Build & Test
@@ -45,6 +53,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.0.17
         with:
           image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          cache-dir: /cache/trivy
           format: template
           template: "@/contrib/sarif.tpl"
           output: trivy-results.sarif
@@ -52,6 +61,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.0.17
         with:
           image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          cache-dir: /cache/trivy
           format: table
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
@@ -61,6 +71,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.0.17
         with:
           image-ref: ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          cache-dir: /cache/trivy
           exit-code: 1
           severity: CRITICAL
           format: table


### PR DESCRIPTION
## Description

Originally this was to introduce caching for trivy, unfortunately we can't use caching for the container image and the marketplace item caching is bugged.

This change includes using the marketplace item for trivy, and including the results as part of the repository security tab.

## Related Links

* https://app.asana.com/0/0/1200385916593852/f
* https://github.com/aquasecurity/trivy-action/releases
* https://github.com/marketplace/actions/cache

## Testing

Confirm security results are posted as part of the checks.

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
