### PR TITLE
Added push to image to hub.docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,16 @@ jobs:
           image-tag: ${{ env.IMAGE_TAG }}
           dockerfile: Dockerfile.${{ matrix.architecture }}
           custom-args: --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from=${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+      - name: Publish Docker
+        uses: elgohr/Publish-Docker-Github-Action@3.04
+        if: ${{ env.IS_DEPLOYMENT == 'true' }}
+        with:
+          name: careerjsm/rails
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          tags: ${{ env.IMAGE_TAG }}
+          buildoptions: --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from=${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
+          no_push: true
       - name: Update Deployment Status (Success)
         if: ${{ env.IS_DEPLOYMENT == 'true' && success() }}
         uses: chrnorm/deployment-status@releases/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
           dockerfile: Dockerfile.${{ matrix.architecture }}
           custom-args: --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from=${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
       - name: Publish to Docker Hub
-        if: ${{ true || env.IS_DEPLOYMENT == 'true' }}
+        if: ${{ env.IS_DEPLOYMENT == 'true' }}
         run: |
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
-          docker tag ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }} careerjsm/rails:${{ env.IMAGE_TAG || 'latest' }}
-          docker push careerjsm/rails:${{ env.IMAGE_TAG || 'latest' }}
+          docker tag ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }} careerjsm/rails:${{ env.IMAGE_TAG }}
+          docker push careerjsm/rails:${{ env.IMAGE_TAG }}
       - name: Update Deployment Status (Success)
         if: ${{ env.IS_DEPLOYMENT == 'true' && success() }}
         uses: chrnorm/deployment-status@releases/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           custom-args: --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from=${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@3.04
-        if: ${{ env.IS_DEPLOYMENT == 'true' }}
+        if: ${{ true || env.IS_DEPLOYMENT == 'true' }}
         with:
           name: careerjsm/rails
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,16 +82,12 @@ jobs:
           image-tag: ${{ env.IMAGE_TAG }}
           dockerfile: Dockerfile.${{ matrix.architecture }}
           custom-args: --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from=${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-      - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@3.04
+      - name: Publish to Docker Hub
         if: ${{ true || env.IS_DEPLOYMENT == 'true' }}
-        with:
-          name: careerjsm/rails
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tags: ${{ env.IMAGE_TAG }}
-          buildoptions: --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from=${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }}
-          no_push: true
+        run: |
+          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          docker tag ${{ steps.build-docker-image-using-cache.outputs.FULL_IMAGE_NAME }}:${{ github.sha }} careerjsm/rails:${{ env.IMAGE_TAG || 'latest' }}
+          docker push careerjsm/rails:${{ env.IMAGE_TAG || 'latest' }}
       - name: Update Deployment Status (Success)
         if: ${{ env.IS_DEPLOYMENT == 'true' && success() }}
         uses: chrnorm/deployment-status@releases/v1


### PR DESCRIPTION
## Description

Changed the deployment to push images to Docker Hub as well as continuing to push to the Github package container repository.

Someone else with access to the organisation in Docker Hub will need to add their `username` and `password` (authentication token will work) into the repository secrets for this repository.

## Related Links

* https://github.com/marketplace/actions/publish-docker
* https://docs.docker.com/engine/reference/commandline/login/

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
