### PR TITLE
Revert ruby 3.0.1 image upgrade

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,8 +3,9 @@
 FROM ruby:2.6.5-alpine3.11
 
 ENV NODE_VERSION 12.22.1-r0
+ENV APK_TOOLS_VERSION 2.10.6-r0
 RUN \
-  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} apk-tools=2.10.6-r0\
+  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} apk-tools=${APK_TOOLS_VERSION}\
   && npm install --global yarn
 
 # Don't inherit local env settings when setting up bundler

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,11 +1,10 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:3.0.1-alpine3.13
+FROM ruby:2.6.5-alpine3.11
 
-ENV NODE_VERSION 14.16.1-r1
-ENV APK_TOOLS_VERSION 2.12.5-r0
+ENV NODE_VERSION 12.22.1-r0
 RUN \
-  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} apk-tools=${APK_TOOLS_VERSION} \
+  apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} apk-tools=2.10.6-r0\
   && npm install --global yarn
 
 # Don't inherit local env settings when setting up bundler
@@ -38,7 +37,13 @@ RUN apk add --update --no-cache git
 
 # Upgrade to fix known security issues
 RUN apk add \
-  ruby=2.7.3-r0
+  # python3=3.8.2-r2 \
+  busybox=1.31.1-r10 \
+  gcc=9.3.0-r0 \
+  perl=5.30.3-r0 \
+  sqlite=3.30.1-r2 \
+  musl-utils=1.1.24-r3 \
+  libgcc=9.3.0-r0
 
 # https://github.com/locomotivecms/wagon/issues/340
 WORKDIR /

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:3.0.1-buster
+FROM ruby:2.6.5-buster
 
 # Replace shell with bash so we can source files
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
@@ -52,3 +52,6 @@ COPY ./entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 3000
+CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]


### PR DESCRIPTION
## Description
Reverting https://github.com/CareerJSM/docker-rails/pull/7/files and running locally the same minus one python patch it looks like?

My starting spot for figuring out where we need to go next. 

## Related Links


## Testing
Pushed up to docker-hub for testing, to test in repo change the following
```
File: packages/core-rails-api/Dockerfile
3: # FROM careerjsm/rails:2.6.5-alpine3.11-node12.21.0 AS base
4: FROM careerjsm/rails:ruby2.6.5-alpine3.11-node12-pr17 AS base
```

Looking at trivy results locally is promising as well

```
$ trivy image careerjsm/rails:ruby2.6.5-alpine3.11-node12-pr17
2021-05-31T20:24:48.783-0400    INFO    Detected OS: alpine
2021-05-31T20:24:48.783-0400    INFO    Detecting Alpine vulnerabilities...
2021-05-31T20:24:48.790-0400    INFO    Number of PL dependency files: 0

careerjsm/rails:ruby2.6.5-alpine3.11-node12-pr17 (alpine 3.11.5)
================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
