### PR TITLE
Update Ruby to 2.6.6 and apk-tools to 2.10.8-r0

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:experimental
 
-FROM ruby:2.6.5-alpine3.11
+FROM ruby:2.6.6-alpine3.11
 
 ENV NODE_VERSION 12.22.4-r0
-ENV APK_TOOLS_VERSION 2.10.7-r0
+ENV APK_TOOLS_VERSION 2.10.8-r0
 RUN \
   apk add --update nodejs=${NODE_VERSION} npm=${NODE_VERSION} apk-tools=${APK_TOOLS_VERSION}\
   && npm install --global yarn


### PR DESCRIPTION
## Description
Ruby 2.6.5 has a critical vulnerability, upgrading to latest 3.11 compatible Ruby version.

Next version for Ruby (2.6.8) is under 3.13 alpine.

## Related Links
https://hub.docker.com/layers/ruby/library/ruby/2.6.6-alpine3.11/images/sha256-96aa63242116fe4c5392fdbbc50f9a0cbcd79b16bdee50f483b42bf7f5119379?context=explore
https://app.asana.com/0/1200749362299539/1200749662453945

## Testing
CI/CD should pass

## Docs
[Authorizations](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/authorization.md) | [Change Yarn Version](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/reference/change-yarn-version.md) | [Packages](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/packages.md) | [Debugging](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/procedures/debugging.md) | [Product](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/product.md) | [System Setup](https://github.com/CareerJSM/careerjsm-code/blob/develop/docs/onboarding/quick-guide-system-setup.md)
